### PR TITLE
D3/D5 setmotors fix and getmotors float cast fix.

### DIFF
--- a/bv80bot/neato_robot/neato_driver/src/neato_driver/neato_driver.py
+++ b/bv80bot/neato_robot/neato_driver/src/neato_driver/neato_driver.py
@@ -253,7 +253,10 @@ class Botvac():
         else:
             self.stop_state = False
 
-        self.sendCmd("setmotor "+str(int(l))+" "+str(int(r))+" "+str(int(s)))
+        self.sendCmd("setmotor" + 
+                     " lwheeldist " + str(int(l)) + 
+                     " rwheeldist " + str(int(r)) + 
+                     " speed " + str(int(s)))
 
     def getMotors(self):
         """ Update values for motors in the self.state dictionary.
@@ -272,7 +275,7 @@ class Botvac():
                 vals,last = self.getResponse()
                 #print vals,last
                 values = vals.split(",")
-                self.state[values[0]] = int(values[1])
+                self.state[values[0]] = float(values[1])
             except Exception as ex:
                 rospy.logerr("Exception Reading Neato motors: " + str(ex))
 


### PR DESCRIPTION
Changed the setmotors command to use explicit parameters to be compatible with D3/D5 models.

Changed getmotors to cast the motor values to float rather than int to get rid of the
[ERROR] [WallTime: 1472859340.261650] Exception Reading Neato motors: invalid literal for int() with base 10: '1.60'
issue.